### PR TITLE
add null possibility to patch types

### DIFF
--- a/ultradom.d.ts
+++ b/ultradom.d.ts
@@ -24,7 +24,7 @@ export function createNode<Attributes>(
  * @param {VNode} node The new virtual DOM representation.
  * @param {Element?} element A DOM element.
  **/
-export function patch(node: VNode, element?: Element): Element
+export function patch(node: VNode, element?: Element | null): Element
 
 declare global {
   namespace JSX {


### PR DESCRIPTION
I need this if not I get error when I put this:
`patch(node, document.getElementById(this.root));`
because typescript consider that maybe I can get null from `document.getElementById(this.root)`
then throw compatibility types error