### PR TITLE
fix h types

### DIFF
--- a/ultradom.d.ts
+++ b/ultradom.d.ts
@@ -1,6 +1,5 @@
 export as namespace ultradom
 
-export type Children = VNode | string | number | null;
 /** The virtual DOM representation of an Element. */
 export interface VNode<Attributes = {}> {
   nodeName: string
@@ -16,7 +15,7 @@ export interface Component<Attributes = {}> {
 export function h<Attributes>(
   nodeName: Component<Attributes> | string,
   attributes?: Attributes | null,
-  children?: Array<Children> | Children,
+  ...children: any[],
 ): VNode<Attributes>
 
 /**

--- a/ultradom.d.ts
+++ b/ultradom.d.ts
@@ -1,5 +1,6 @@
 export as namespace ultradom
 
+export type Children = VNode | string | number | null;
 /** The virtual DOM representation of an Element. */
 export interface VNode<Attributes = {}> {
   nodeName: string
@@ -15,7 +16,7 @@ export interface Component<Attributes = {}> {
 export function h<Attributes>(
   nodeName: Component<Attributes> | string,
   attributes?: Attributes | null,
-  ...children: any[],
+  ...children: Array<Children | Children[]>,
 ): VNode<Attributes>
 
 /**

--- a/ultradom.d.ts
+++ b/ultradom.d.ts
@@ -18,7 +18,6 @@ export function h<Attributes>(
   children?: Array<VNode | string | number | null>
 ): VNode<Attributes>
 
-
 /**
  * Patch a DOM element to match the supplied virtual DOM representation. If no element is given, create and return a new DOM element.
  *

--- a/ultradom.d.ts
+++ b/ultradom.d.ts
@@ -14,9 +14,10 @@ export interface Component<Attributes = {}> {
 
 export function h<Attributes>(
   nodeName: Component<Attributes> | string,
-  attributes?: Attributes,
-  ...children: Array<VNode | string | number | null>
+  attributes?: Attributes | null,
+  children?: Array<VNode | string | number | null>
 ): VNode<Attributes>
+
 
 /**
  * Patch a DOM element to match the supplied virtual DOM representation. If no element is given, create and return a new DOM element.

--- a/ultradom.d.ts
+++ b/ultradom.d.ts
@@ -1,5 +1,6 @@
 export as namespace ultradom
 
+export type Children = VNode | string | number | null;
 /** The virtual DOM representation of an Element. */
 export interface VNode<Attributes = {}> {
   nodeName: string
@@ -15,7 +16,7 @@ export interface Component<Attributes = {}> {
 export function h<Attributes>(
   nodeName: Component<Attributes> | string,
   attributes?: Attributes | null,
-  children?: Array<VNode | string | number | null>
+  children?: Array<Children> | Children,
 ): VNode<Attributes>
 
 /**


### PR DESCRIPTION
with the type which there is now is not compatible with this:

```javascript
{
  nodeName: "div",
  attributes: {},
  children: [
    {
      nodeName: "h1",
      attributes: {},
      children: 0
    },
    {
      nodeName: "button",
      attributes: { ... },
      children: "-"
    },
    {
      nodeName: "button",
      attributes: { ... },
      children: "+"
    }
  ]
}
```
to make it compatible is required to change the h types to:
```javascript
export type Children = VNode | string | number | null;

export function h<Attributes>(
  nodeName: Component<Attributes> | string,
  attributes?: Attributes,
  children?: Array<Children> | Children,
): VNode<Attributes>
```
instead of
```javascript
export function h<Attributes>(
  nodeName: Component<Attributes> | string,
  attributes?: Attributes,
  ...children: Array<VNode | string | number | null>
): VNode<Attributes>
```
because this `...children: Array<VNode | string | number | null>` is translated to:
```javascript
{
  nodeName: "div",
  attributes: {},
    {
      nodeName: "h1",
      attributes: {},
      children: 0
    },
    {
      nodeName: "button",
      attributes: { ... },
      children: "-"
    },
    {
      nodeName: "button",
      attributes: { ... },
      children: "+"
    }
}
```
therefore it is not possible to put an array after the attributes