### PR TITLE
add types file to package.json so typescript can find it

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "module": "ultradom.m.js",
   "license": "MIT",
   "repository": "jorgebucaran/ultradom",
+  "types": "ultradom.d.ts",
   "files": [
     "ultradom.m.js",
     "ultradom.d.ts",


### PR DESCRIPTION
This PR adds the `types` field to the package.json file following the official recommendations:

https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html

I had trouble with typescript not finding the global `JSX` type definitions defined in `ultradom.d.ts` until I did this.